### PR TITLE
Destructor ESP32PWM implementation

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -29,7 +29,11 @@ ESP32PWM::ESP32PWM() {
 }
 
 ESP32PWM::~ESP32PWM() {
-	// TODO Auto-generated destructor stub
+	if (attachedState)
+	{
+		ledcDetachPin(pin);
+	}
+	deallocate();
 }
 
 double ESP32PWM::_ledcSetupTimerFreq(uint8_t chan, double freq,

--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -29,7 +29,10 @@ ESP32PWM::ESP32PWM() {
 }
 
 ESP32PWM::~ESP32PWM() {
-	detachPin(pin);
+	if (attached()) {
+		ledcDetachPin(pin);
+	}
+	deallocate();
 }
 
 double ESP32PWM::_ledcSetupTimerFreq(uint8_t chan, double freq,
@@ -224,9 +227,7 @@ void ESP32PWM::attachPin(uint8_t pin, double freq, uint8_t resolution_bits) {
 	attachPin(pin);
 }
 void ESP32PWM::detachPin(int pin) {
-	if (attached()) {
-		ledcDetachPin(pin);
-	}
+	ledcDetachPin(pin);
 	deallocate();
 }
 /* Side effects of frequency changes happen because of shared timers

--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -29,11 +29,7 @@ ESP32PWM::ESP32PWM() {
 }
 
 ESP32PWM::~ESP32PWM() {
-	if (attachedState)
-	{
-		ledcDetachPin(pin);
-	}
-	deallocate();
+	detachPin(pin);
 }
 
 double ESP32PWM::_ledcSetupTimerFreq(uint8_t chan, double freq,
@@ -228,7 +224,9 @@ void ESP32PWM::attachPin(uint8_t pin, double freq, uint8_t resolution_bits) {
 	attachPin(pin);
 }
 void ESP32PWM::detachPin(int pin) {
-	ledcDetachPin(pin);
+	if (attached()) {
+		ledcDetachPin(pin);
+	}
 	deallocate();
 }
 /* Side effects of frequency changes happen because of shared timers


### PR DESCRIPTION
The destructor the class ESP32PWM was not yet implemented.

This causes problems when using Servo objects locally in a function: see Issue https://github.com/madhephaestus/ESP32Servo/issues/6 
