### PR TITLE
Fix tone functions

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -179,7 +179,7 @@ double ESP32PWM::writeTone(double freq) {
 				ChannelUsed[pwm]->adjustFrequencyLocal(freq,
 						ChannelUsed[pwm]->getDutyScaled());
 			}
-			write(1 << (resolutionBits-1)); // WriteScaled(0.5);
+			write(1 << (resolutionBits-1)); // writeScaled(0.5);
 		}
 	}
 

--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -179,6 +179,7 @@ double ESP32PWM::writeTone(double freq) {
 				ChannelUsed[pwm]->adjustFrequencyLocal(freq,
 						ChannelUsed[pwm]->getDutyScaled());
 			}
+			write(1 << (resolutionBits-1)); // WriteScaled(0.5);
 		}
 	}
 

--- a/src/ESP32Tone.cpp
+++ b/src/ESP32Tone.cpp
@@ -14,8 +14,8 @@ void tone(int APin,unsigned int frequency){
 		chan = new ESP32PWM();
 	}
 	if(!chan->attached()){
-		chan->attachPin(APin,1000, 10); // This adds the PWM instance to the factory list
-		//Serial.println("Attaching AnalogWrite : "+String(APin)+" on PWM "+String(chan->getChannel()));
+		chan->attachPin(APin,frequency, 10); // This adds the PWM instance to the factory list
+		//Serial.println("Attaching tone : "+String(APin)+" on PWM "+String(chan->getChannel()));
 	}
 	chan->writeTone(frequency);// update the time base of the PWM
 }


### PR DESCRIPTION
This fixes issue
https://github.com/madhephaestus/ESP32Servo/issues/10

- the duty cycle needs to be set at 50% for maximum volume
- the channel needs to be at the requested frequency instead of 1000 Hz (also better for not mixing analogWrite channels with tone channels).
