### PR TITLE
Fix memory leak in tone/noTone

### DIFF
--- a/src/ESP32Tone.cpp
+++ b/src/ESP32Tone.cpp
@@ -30,6 +30,9 @@ void noTone(int pin){
 	ESP32PWM* chan = pwmFactory(pin);
 	if (chan != NULL) {
 		if(chan->attached())
+		{
 			chan->detachPin(pin);
+			delete chan;
+		}
 	}
 }


### PR DESCRIPTION
When calling noTone after tone, this will detach but not delete the ESP32PWM object. This creates a memory leak.