### PR TITLE
Define PWMRANGE for compatibility with ESP8266

### DIFF
--- a/src/analogWrite.h
+++ b/src/analogWrite.h
@@ -4,6 +4,8 @@
 #include <esp32-hal-ledc.h>
 #include <Arduino.h>
 
+#define PWMRANGE 255
+
   void analogWrite( uint8_t APin, uint16_t AValue );
 
 #endif


### PR DESCRIPTION
By defining PWMRANGE, it is possible to write code which is exactly the same on ESP8266 and ESP32 by using e.g. the map function (PWMRANGE is 1023 on ESP8266)