### PR TITLE
Fix bug in allocation algorithm

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -67,19 +67,22 @@ int ESP32PWM::allocatenext(double freq) {
 				//Serial.println("Free channel timer "+String(i)+" at freq "+String(freq)+" remaining "+String(4-timerCount[i]));
 
 				timerNum = i;
-				int myTimerNumber = timerAndIndexToChannel(timerNum,
-						timerCount[timerNum]);
-				if (myTimerNumber >= 0) {
-					pwmChannel = myTimerNumber;
-// 					Serial.println(
+				for (int index=0; index<4; ++index)
+				{
+					int myTimerNumber = timerAndIndexToChannel(timerNum,index);
+					if ((myTimerNumber >= 0)  && (!ChannelUsed[myTimerNumber]))
+					{
+						pwmChannel = myTimerNumber;
+// 						Serial.println(
 // 							"PWM on ledc channel #" + String(pwmChannel)
 // 									+ " using 'timer " + String(timerNum)
 // 									+ "' to freq " + String(freq) + "Hz");
-					ChannelUsed[pwmChannel] = this;
-					timerCount[timerNum]++;
-					PWMCount++;
-					myFreq = freq;
-					return pwmChannel;
+						ChannelUsed[pwmChannel] = this;
+						timerCount[timerNum]++;
+						PWMCount++;
+						myFreq = freq;
+						return pwmChannel;
+					}
 				}
 			} else {
 //				if(timerFreqSet[i]>0)


### PR DESCRIPTION
When some time ago, the de-allocation of an ESP32PWM object was introduced, the allocation algorithm wasn't updated. As a result the allocation algorithm is no longer correct as it will not reuse a previous de-allocated channel. 

This causes leaking memory, channels and finally stopping the program when using e.g. lots of analogWrite with zero and non-zero values because analogWrite with value 0 calls deallocation. But also with Servo objects, allocation will go wrong when deallocating.

The proposed solution will not allocate by simply iterating, but by checking which slot is free. Finally, the random crashes are gone.

example:
analogWrite(pin1,100); // allocates the first channel
analogWrite(pin2,100); // allocates the second channel
analogWrite(pin1,0); // this deallocates the first channel
analogWrite(pin1,100); 
=> this should reallocate the first allocated channel, but in reality it overwrites the second channel 

