### PR TITLE
Changes to support ESP32-S2

### DIFF
--- a/examples/Knob/Knob.ino
+++ b/examples/Knob/Knob.ino
@@ -42,9 +42,15 @@
 Servo myservo;  // create servo object to control a servo
 
 // Possible PWM GPIO pins on the ESP32: 0(used by on-board button),2,4,5(used by on-board LED),12-19,21-23,25-27,32-33 
+// Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42 
 int servoPin = 18;      // GPIO pin used to connect the servo control (digital out)
 // Possible ADC pins on the ESP32: 0,2,4,12-15,32-39; 34-39 are recommended for analog input
+// Possible ADC pins on the ESP32-S2: 1-20 are recommended for analog input
+#if defined(ARDUINO_ESP32S2_DEV)
+int potPin = 10;        // GPIO pin used to connect the potentiometer (analog in)
+#else
 int potPin = 34;        // GPIO pin used to connect the potentiometer (analog in)
+#endif
 int ADC_Max = 4096;     // This is the default ADC max value on the ESP32 (12 bit ADC width);
                         // this width can be set (in low-level oode) from 9-12 bits, for a
                         // a range of max values of 512-4096

--- a/examples/Multiple-Servo-Example-Arduino/Multiple-Servo-Example-Arduino.ino
+++ b/examples/Multiple-Servo-Example-Arduino/Multiple-Servo-Example-Arduino.ino
@@ -46,11 +46,16 @@ int minUs = 1000;
 int maxUs = 2000;
 
 // These are all GPIO pins on the ESP32
-// Recommended pins include 2,4,12-19,21-23,25-27,32-33 
+// Recommended pins include 2,4,12-19,21-23,25-27,32-33
+// for the ESP32-S2 the GPIO pins are 1-21,26,33-42
 int servo1Pin = 15;
 int servo2Pin = 16;
 int servo3Pin = 14;
+#if defined(ARDUINO_ESP32S2_DEV)
+int servo4Pin = 13;
+#else
 int servo4Pin = 32;
+#endif
 int servo5Pin = 4;
 
 int pos = 0;      // position in degrees
@@ -74,7 +79,11 @@ void setup() {
 void loop() {
 	servo1.attach(servo1Pin, minUs, maxUs);
 	servo2.attach(servo2Pin, minUs, maxUs);
+#if defined(ARDUINO_ESP32S2_DEV)
+	pwm.attachPin(37, 10000);//10khz
+#else
 	pwm.attachPin(27, 10000);//10khz
+#endif
 	servo3.attach(servo3Pin, minUs, maxUs);
 	servo4.attach(servo4Pin, minUs, maxUs);
 

--- a/examples/Sweep/Sweep.ino
+++ b/examples/Sweep/Sweep.ino
@@ -43,7 +43,12 @@ Servo myservo;  // create servo object to control a servo
 
 int pos = 0;    // variable to store the servo position
 // Recommended PWM GPIO pins on the ESP32 include 2,4,12-19,21-23,25-27,32-33 
+// Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42
+#if defined(ARDUINO_ESP32S2_DEV)
+int servoPin = 17;
+#else
 int servoPin = 18;
+#endif
 
 void setup() {
 	// Allow allocation of all timers

--- a/examples/analogWriteExample/analogWriteExample.ino
+++ b/examples/analogWriteExample/analogWriteExample.ino
@@ -5,7 +5,7 @@
  This sketch was written for the Arduino Mega, and will not work on previous boards.
 
  The circuit:
- * LEDs attached from pins 2 through 13 to ground.
+ * LEDs attached from pins 2 through 13 to ground. or for ESP32-S2 pins 1-17,19-21,26,33-42
 
  created 8 Feb 2009
  by Tom Igoe
@@ -15,8 +15,13 @@
  */
 // These constants won't change.  They're used to give names
 // to the pins used:
+#if defined(ARDUINO_ESP32S2_DEV)
+const int lowestPin = 1;
+const int highestPin = 42;
+#else
 const int lowestPin = 2;
 const int highestPin = 33;
+#endif
 #include <ESP32Servo.h>
 Servo myservo;
 
@@ -43,8 +48,14 @@ void loop() {
 						thisPin == 25 || // one of the  2 DAC outputs, no timer needed
 						thisPin == 26)) { // one of the 2 DAC outputs, no timer needed
 			if (pwmFactory(thisPin) == NULL) { // check if its the first time for the pin or its a DAC
+#if defined(ARDUINO_ESP32S2_DEV)
+				if (thisPin == 17 || // one of the 2 DAC outputs, no timer needed
+						thisPin == 18)
+#else
 				if (thisPin == 25 || // one of the 2 DAC outputs, no timer needed
-						thisPin == 26) {
+						thisPin == 26)
+#endif
+				{
 					Serial.println("DAC to pin " + String(thisPin));
 				} else
 					Serial.println("Writing to pin " + String(thisPin));

--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -236,7 +236,12 @@ void ESP32PWM::attachPin(uint8_t pin) {
 	} else {
 		Serial.println(
 				"ERROR PWM channel unavailible on pin requested! " + String(pin)
-						+ "\r\nPWM availible on: 2,4,5,12-19,21-23,25-27,32-33");
+#if defined(ARDUINO_ESP32S2_DEV)
+						+ "\r\nPWM availible on: 1-21,26,33-42"
+#else
+						+ "\r\nPWM availible on: 2,4,5,12-19,21-23,25-27,32-33"
+#endif
+		);
 		return;
 	}
 	//Serial.print(" on pin "+String(pin));

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -97,6 +97,11 @@ public:
 		return pin;
 	}
 	static bool hasPwm(int pin) {
+#if defined(ARDUINO_ESP32S2_DEV)
+		if ((pin >=1 && pin <= 21) || //20
+				(pin == 26) || //1
+				(pin >= 33 && pin <= 42)) //10
+#else
 		if ((pin == 2) || //1
 				(pin == 4) || //1
 				(pin == 5) || //1
@@ -104,6 +109,7 @@ public:
 				((pin >= 21) && (pin <= 23)) || //3
 				((pin >= 25) && (pin <= 27)) || //3
 				(pin == 32) || (pin == 33)) //2
+#endif
 			return true;
 		return false;
 	}

--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -80,7 +80,8 @@ int Servo::attach(int pin, int min, int max)
 {
 
 #ifdef ENFORCE_PINS
-        // Recommend only the following pins 2,4,12-19,21-23,25-27,32-33
+        // ESP32 Recommend only the following pins 2,4,12-19,21-23,25-27,32-33
+		// ESP32-S2 only the following pins 1-21,26,33-42
         if (pwm.hasPwm(pin))
         {
 #endif
@@ -97,7 +98,13 @@ int Servo::attach(int pin, int min, int max)
         }
         else
         {
-        	Serial.println("This pin can not be a servo: "+String(pin)+"\r\nServo availible on: 2,4,5,12-19,21-23,25-27,32-33");
+        	Serial.println("This pin can not be a servo: "+String(pin)+
+#if defined(ARDUINO_ESP32S2_DEV)
+				"\r\nServo availible on: 1-21,26,33-42"
+#else
+				"\r\nServo availible on: 2,4,5,12-19,21-23,25-27,32-33"
+#endif
+			);
             return 0;
         }
 #endif


### PR DESCRIPTION
These are the changes needed to support the ESP32-S2. 

In order to get the Arduino code to support S2 you need to use an unofficial release. That release doesn't seem to support the ESP32 at the same time. Here is a link to a video showing how to setup the Arduino for ESP32-S2. [https://tutorial.cytron.io/2020/06/25/program-esp32-s2-using-arduino-ide-unofficial/](url).

I have compiled for both the normal ESP32 and the S2. I used the Espressif datasheet on the ESP32-S2 WROOM and WROVER to get the pins that are available.

Michael