### PR TITLE
Using double instead of floats, as ESP32 doesn't allows floats in ISR

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -152,18 +152,18 @@ double ESP32PWM::setup(double freq, uint8_t resolution_bits) {
 	}
 	return ledcSetup(getChannel(), freq, resolution_bits);
 }
-float ESP32PWM::getDutyScaled() {
-	return mapf((float) myDuty, 0, (float) ((1 << resolutionBits) - 1), 0.0,
+double ESP32PWM::getDutyScaled() {
+	return mapf((double) myDuty, 0, (double) ((1 << resolutionBits) - 1), 0.0,
 			1.0);
 }
-void ESP32PWM::writeScaled(float duty) {
-	write(mapf(duty, 0.0, 1.0, 0, (float) ((1 << resolutionBits) - 1)));
+void ESP32PWM::writeScaled(double duty) {
+	write(mapf(duty, 0.0, 1.0, 0, (double) ((1 << resolutionBits) - 1)));
 }
 void ESP32PWM::write(uint32_t duty) {
 	myDuty = duty;
 	ledcWrite(getChannel(), duty);
 }
-void ESP32PWM::adjustFrequencyLocal(double freq, float dutyScaled) {
+void ESP32PWM::adjustFrequencyLocal(double freq, double dutyScaled) {
 	timerFreqSet[getTimer()] = (long) freq;
 	myFreq = freq;
 	if (attached()) {
@@ -177,7 +177,7 @@ void ESP32PWM::adjustFrequencyLocal(double freq, float dutyScaled) {
 		writeScaled(dutyScaled);
 	}
 }
-void ESP32PWM::adjustFrequency(double freq, float dutyScaled) {
+void ESP32PWM::adjustFrequency(double freq, double dutyScaled) {
 	if(dutyScaled<0)
 		dutyScaled=getDutyScaled();
 	writeScaled(dutyScaled);

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -30,9 +30,9 @@ private:
 
 	bool checkFrequencyForSideEffects(double freq);
 
-	void adjustFrequencyLocal(double freq, float dutyScaled);
-	static float mapf(float x, float in_min, float in_max, float out_min,
-			float out_max) {
+	void adjustFrequencyLocal(double freq, double dutyScaled);
+	static double mapf(double x, double in_min, double in_max, double out_min,
+			double out_max) {
 		if(x>in_max)
 			return out_max;
 		if(x<in_min)
@@ -60,16 +60,16 @@ public:
 	// write raw duty cycle
 	void write(uint32_t duty);
 	// Write a duty cycle to the PWM using a unit vector from 0.0-1.0
-	void writeScaled(float duty);
+	void writeScaled(double duty);
 	//Adjust frequency
 	double writeTone(double freq);
 	double writeNote(note_t note, uint8_t octave);
-	void adjustFrequency(double freq, float dutyScaled=-1);
+	void adjustFrequency(double freq, double dutyScaled=-1);
 
 	// Read pwm data
 	uint32_t read();
 	double readFreq();
-	float getDutyScaled();
+	double getDutyScaled();
 
 	//Timer data
 	static int timerAndIndexToChannel(int timer, int index);

--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -232,12 +232,12 @@ int Servo::readTimerWidth()
 
 int Servo::usToTicks(int usec)
 {
-    return (int)((float)usec / ((float)REFRESH_USEC / (float)this->timer_width_ticks)*(((float)REFRESH_CPS)/50.0));
+    return (int)((double)usec / ((double)REFRESH_USEC / (double)this->timer_width_ticks)*(((double)REFRESH_CPS)/50.0));
 }
 
 int Servo::ticksToUs(int ticks)
 {
-    return (int)((float)ticks * ((float)REFRESH_USEC / (float)this->timer_width_ticks)/(((float)REFRESH_CPS)/50.0));
+    return (int)((double)ticks * ((double)REFRESH_USEC / (double)this->timer_width_ticks)/(((double)REFRESH_CPS)/50.0));
 }
 
  


### PR DESCRIPTION
These changes shouldn't make any difference in functioning, but I would recommend testing it in other use-cases.
Hope these changes can help others!

More context:
https://github.com/espressif/arduino-esp32/issues/3661#issuecomment-578224260

Have a nice day!