### PR TITLE
add support for ESP32-S3 and ESP32-C3 and match chip instead of board

### DIFF
--- a/examples/Knob/Knob.ino
+++ b/examples/Knob/Knob.ino
@@ -42,12 +42,16 @@
 Servo myservo;  // create servo object to control a servo
 
 // Possible PWM GPIO pins on the ESP32: 0(used by on-board button),2,4,5(used by on-board LED),12-19,21-23,25-27,32-33 
-// Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42 
+// Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42
+// Possible PWM GPIO pins on the ESP32-S3: 0(used by on-board button),1-21,35-45,47,48(used by on-board LED)
+// Possible PWM GPIO pins on the ESP32-C3: 0(used by on-board button),1-7,8(used by on-board LED),9-10,18-21
 int servoPin = 18;      // GPIO pin used to connect the servo control (digital out)
 // Possible ADC pins on the ESP32: 0,2,4,12-15,32-39; 34-39 are recommended for analog input
 // Possible ADC pins on the ESP32-S2: 1-20 are recommended for analog input
-#if defined(ARDUINO_ESP32S2_DEV)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
 int potPin = 10;        // GPIO pin used to connect the potentiometer (analog in)
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+int potPin = 4;         // GPIO pin used to connect the potentiometer (analog in)
 #else
 int potPin = 34;        // GPIO pin used to connect the potentiometer (analog in)
 #endif

--- a/examples/Multiple-Servo-Example-Arduino/Multiple-Servo-Example-Arduino.ino
+++ b/examples/Multiple-Servo-Example-Arduino/Multiple-Servo-Example-Arduino.ino
@@ -48,15 +48,25 @@ int maxUs = 2000;
 // These are all GPIO pins on the ESP32
 // Recommended pins include 2,4,12-19,21-23,25-27,32-33
 // for the ESP32-S2 the GPIO pins are 1-21,26,33-42
+// for the ESP32-S3 the GPIO pins are 1-21,35-45,47-48
+// for the ESP32-C3 the GPIO pins are 1-10,18-21
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
+int servo1Pin = 7;
+int servo2Pin = 6;
+int servo3Pin = 5;
+int servo4Pin = 4;
+int servo5Pin = 3;
+#else
 int servo1Pin = 15;
 int servo2Pin = 16;
 int servo3Pin = 14;
-#if defined(ARDUINO_ESP32S2_DEV)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
 int servo4Pin = 13;
 #else
 int servo4Pin = 32;
 #endif
 int servo5Pin = 4;
+#endif
 
 int pos = 0;      // position in degrees
 ESP32PWM pwm;
@@ -79,8 +89,10 @@ void setup() {
 void loop() {
 	servo1.attach(servo1Pin, minUs, maxUs);
 	servo2.attach(servo2Pin, minUs, maxUs);
-#if defined(ARDUINO_ESP32S2_DEV)
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32C3)
 	pwm.attachPin(37, 10000);//10khz
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+	pwm.attachPin(7, 10000);//10khz
 #else
 	pwm.attachPin(27, 10000);//10khz
 #endif

--- a/examples/Sweep/Sweep.ino
+++ b/examples/Sweep/Sweep.ino
@@ -44,8 +44,12 @@ Servo myservo;  // create servo object to control a servo
 int pos = 0;    // variable to store the servo position
 // Recommended PWM GPIO pins on the ESP32 include 2,4,12-19,21-23,25-27,32-33 
 // Possible PWM GPIO pins on the ESP32-S2: 0(used by on-board button),1-17,18(used by on-board LED),19-21,26,33-42
-#if defined(ARDUINO_ESP32S2_DEV)
+// Possible PWM GPIO pins on the ESP32-S3: 0(used by on-board button),1-21,35-45,47,48(used by on-board LED)
+// Possible PWM GPIO pins on the ESP32-C3: 0(used by on-board button),1-7,8(used by on-board LED),9-10,18-21
+#if defined(CONFIG_IDF_TARGET_ESP32S2) || defined(CONFIG_IDF_TARGET_ESP32S3)
 int servoPin = 17;
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+int servoPin = 7;
 #else
 int servoPin = 18;
 #endif

--- a/examples/analogWriteExample/analogWriteExample.ino
+++ b/examples/analogWriteExample/analogWriteExample.ino
@@ -15,9 +15,12 @@
  */
 // These constants won't change.  They're used to give names
 // to the pins used:
-#if defined(ARDUINO_ESP32S2_DEV)
+#if defined(ARDUINO_ESP32S2_DEV) || defined(ARDUINO_ESP32S3_DEV)
 const int lowestPin = 1;
 const int highestPin = 42;
+#elif defined(ARDUINO_ESP32C3_DEV)
+const int lowestPin = 1;
+const int highestPin = 19;
 #else
 const int lowestPin = 2;
 const int highestPin = 33;
@@ -51,6 +54,8 @@ void loop() {
 #if defined(ARDUINO_ESP32S2_DEV)
 				if (thisPin == 17 || // one of the 2 DAC outputs, no timer needed
 						thisPin == 18)
+#elif defined(ARDUINO_ESP32C3_DEV) || defined(ARDUINO_ESP32S3_DEV)
+				if (1 == 0) //  no DAC outputs for these chips
 #else
 				if (thisPin == 25 || // one of the 2 DAC outputs, no timer needed
 						thisPin == 26)

--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -235,12 +235,19 @@ void ESP32PWM::attachPin(uint8_t pin) {
 		ledcAttachPin(pin, getChannel());
 	} else {
 		Serial.println(
-				"ERROR PWM channel unavailible on pin requested! " + String(pin)
-#if defined(ARDUINO_ESP32S2_DEV)
-						+ "\r\nPWM availible on: 1-21,26,33-42"
+				"ERROR PWM channel unavailable on pin requested! " + String(pin)
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+						+ "\r\nPWM available on: 1-21,26,33-42"
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+						+ "\r\nPWM available on: 1-21,35-45,47-48"
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+						+ "\r\nPWM available on: 1-10,18-21"
 #else
-						+ "\r\nPWM availible on: 2,4,5,12-19,21-23,25-27,32-33"
+						+ "\r\nPWM available on: 2,4,5,12-19,21-23,25-27,32-33"
 #endif
+
+// Possible PWM GPIO pins on the ESP32-S3: 0(used by on-board button),1-21,35-45,47,48(used by on-board LED)
+// Possible PWM GPIO pins on the ESP32-C3: 0(used by on-board button),1-7,8(used by on-board LED),9-10,18-21
 		);
 		return;
 	}

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -97,10 +97,17 @@ public:
 		return pin;
 	}
 	static bool hasPwm(int pin) {
-#if defined(ARDUINO_ESP32S2_DEV)
-		if ((pin >=1 && pin <= 21) || //20
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+		if ((pin >=1 && pin <= 21) || //21
 				(pin == 26) || //1
 				(pin >= 33 && pin <= 42)) //10
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+		if ((pin >=1 && pin <= 21) || //20
+				(pin >= 35 && pin <= 45) || //11
+				(pin == 47) || (pin == 48)) //2
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+		if ((pin >=1 && pin <= 10) || //11
+				(pin >= 18 && pin <= 21)) //4
 #else
 		if ((pin == 2) || //1
 				(pin == 4) || //1

--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -98,11 +98,18 @@ int Servo::attach(int pin, int min, int max)
         }
         else
         {
+#ifdef __XTENSA_esp32s3__
+if(
+#endif
         	Serial.println("This pin can not be a servo: "+String(pin)+
-#if defined(ARDUINO_ESP32S2_DEV)
-				"\r\nServo availible on: 1-21,26,33-42"
+#if defined(CONFIG_IDF_TARGET_ESP32S2)
+				"\r\nServo available on: 1-21,26,33-42"
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+			        "\r\nPWM available on: 1-21,35-45,47-48"
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+				"\r\nPWM available on: 1-10,18-21"
 #else
-				"\r\nServo availible on: 2,4,5,12-19,21-23,25-27,32-33"
+				"\r\nServo available on: 2,4,5,12-19,21-23,25-27,32-33"
 #endif
 			);
             return 0;


### PR DESCRIPTION
I needed to use this library with the ESP32-S3, and noticed it would not let me use some pins. 

So, i added support for the ESP32-S3 and the ESP32-C3, while we're at it. Also, i changed the chip matching so it actually matches for the chip in question (yes, using IDF flags, it works under arduino and i couldn't find a nicer way), and not just the dev boards, since arduino has way more boards defined with these chips than just the dev boards.