### PR TITLE
Add release method to release servos

### DIFF
--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -174,6 +174,12 @@ void Servo::writeMicroseconds(int value)
     }
 }
 
+void Servo::release()
+{
+    if (this->attached())   // ensure channel is valid
+        pwm.write(0);
+}
+
 int Servo::read() // return the value as degrees
 {
     return (map(readMicroseconds()+1, this->min, this->max, 0, 180));

--- a/src/ESP32Servo.h
+++ b/src/ESP32Servo.h
@@ -136,6 +136,7 @@ public:
 	void detach();
 	void write(int value); // if value is < MIN_PULSE_WIDTH its treated as an angle, otherwise as pulse width in microseconds
 	void writeMicroseconds(int value);     // Write pulse width in microseconds
+	void release();
 	int read(); // returns current pulse width as an angle between 0 and 180 degrees
 	int readMicroseconds(); // returns current pulse width in microseconds for this servo
 	bool attached(); // return true if this servo is attached, otherwise false


### PR DESCRIPTION
It may be useful to release the servos(so that the motor inside the servo does not burn up).

Use case is a latch.  Drive the servo 0 degrees(the servo may only be able to reach, for example, 40 degrees) for 100ms then release the servo.    To unlatch drive the servo 180 degrees(again the servo may only be able to reach 130 degrees) for 100ms then release the servo