### PR TITLE
pwm channels number definition depends on chip

### DIFF
--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -9,9 +9,9 @@
 #define LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
 #include "esp32-hal-ledc.h"
 
-#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#if defined(CONFIG_IDF_TARGET_ESP32C3)
 #define NUM_PWM 6
-#elif defined(CONFIG_IDF_TARGET_ESP32S2)   ||  defined(CONFIG_IDF_TARGET_ESP32C3)
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)   ||  defined(CONFIG_IDF_TARGET_ESP32S3)
 #define NUM_PWM 8
 #else 
 #define NUM_PWM 16

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -8,7 +8,15 @@
 #ifndef LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
 #define LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
 #include "esp32-hal-ledc.h"
+
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#define NUM_PWM 6
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)   ||  defined(CONFIG_IDF_TARGET_ESP32C3)
+#define NUM_PWM 8
+#else 
 #define NUM_PWM 16
+#endif
+
 #define PWM_BASE_INDEX 0
 #define USABLE_ESP32_PWM (NUM_PWM-PWM_BASE_INDEX)
 #include <cstdint>


### PR DESCRIPTION
according to this documentation [link](https://docs.espressif.com/projects/esp-idf/en/v5.0/esp32s3/hw-reference/chip-series-comparison.html)

different kinds of esp32 have different number of pwm channels.

defining 16 channels makes my esp32s3 log to debug that there is no more channels and only 2 pwm outputs work.