### PR TITLE
Implemented changes to work with ESP S3 and S2

### DIFF
--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -8,6 +8,9 @@
 #ifndef LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
 #define LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
 #include "esp32-hal-ledc.h"
+#if defined(ARDUINO)
+	#include "Arduino.h"
+#endif
 
 #if defined(CONFIG_IDF_TARGET_ESP32C3)
 #define NUM_PWM 6
@@ -21,7 +24,6 @@
 #define USABLE_ESP32_PWM (NUM_PWM-PWM_BASE_INDEX)
 #include <cstdint>
 
-#include "Arduino.h"
 class ESP32PWM {
 private:
 

--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -51,7 +51,9 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 */
 
 #include <ESP32Servo.h>
-#include "Arduino.h"
+#if defined(ARDUINO)
+	#include "Arduino.h"
+#endif
 
 //
 Servo::Servo()


### PR DESCRIPTION
The import of Arduino.h was below the NUM_PWM setting for different boards, thus was not being enforced. This caused only 4 servos to be allotted to LEDc channels and the rest not being attached. I have tested this with an ESP32 S3.

Apologies for the formatting error. Fixed and pushed. 