### PR TITLE
Bugfix: +1 on read was throwing off accuracy

### DIFF
--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -184,7 +184,7 @@ void Servo::release()
 
 int Servo::read() // return the value as degrees
 {
-    return (map(readMicroseconds()+1, this->min, this->max, 0, 180));
+    return (map(readMicroseconds(), this->min, this->max, 0, 180));
 }
 
 int Servo::readMicroseconds()


### PR DESCRIPTION
Noticed that when I was reading the current value from the servo, incrementing or decrementing it by one, and then writing it back - that the servo would only move in one direction.  Tracked it down to this extraneous +1 in the read that isn't mirrored in the write.