### PR TITLE
Moved all Error and Debug prints to ESP_LOG

### DIFF
--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -55,7 +55,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
 	#include "Arduino.h"
 #endif
 
-//
+static const char* TAG = "ESP32Servo";
+
 Servo::Servo()
 {		// initialize this channel with plausible values, except pin # (we set pin # when attached)
 	REFRESH_CPS = 50;
@@ -103,17 +104,16 @@ int Servo::attach(int pin, int min, int max)
 #ifdef __XTENSA_esp32s3__
 if(
 #endif
-        	Serial.println("This pin can not be a servo: "+String(pin)+
+
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
-				"\r\nServo available on: 1-21,26,33-42"
+				ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 1-21,26,33-42", pin);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-			        "\r\nPWM available on: 1-21,35-45,47-48"
+			    ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 1-21,35-45,47-48", pin);
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
-				"\r\nPWM available on: 1-10,18-21"
+				ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 1-10,18-21", pin);
 #else
-				"\r\nServo available on: 2,4,5,12-19,21-23,25-27,32-33"
+				ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 2,4,5,12-19,21-23,25-27,32-33",pin);
 #endif
-			);
             return 0;
         }
 #endif
@@ -129,7 +129,7 @@ if(
         // Set up this channel
         // if you want anything other than default timer width, you must call setTimerWidth() before attach
         pwm.attachPin(this->pinNumber,REFRESH_CPS, this->timer_width );   // GPIO pin assigned to channel
-        //Serial.println("Attaching servo : "+String(pin)+" on PWM "+String(pwm.getChannel()));
+        ESP_LOGI(TAG, "Attaching servo : %d on PWM %d",pin,pwm.getChannel());
         return pwm.getChannel();
 }
 


### PR DESCRIPTION
Moved all the debug and error Serial prints in ESP32PWM.cpp and ESP32Servo.cpp to the standard ESP Logging format. This allows users to get debug messages when they set the logging level flag during compilation.