### PR TITLE
Update ESP32PWM.cpp

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -50,14 +50,14 @@ ESP32PWM::ESP32PWM() {
 
 ESP32PWM::~ESP32PWM() {
 	if (attached()) {
-		ledcDetach(pin);
+		ledcDetachPin(pin);
 	}
 	deallocate();
 }
 
 double ESP32PWM::_ledcSetupTimerFreq(uint8_t pin, double freq,
 		uint8_t bit_num) {
-	return ledcAttach(pin, freq, bit_num);
+	return ledcAttachPin(pin, freq, bit_num);
 
 }
 
@@ -147,12 +147,12 @@ double ESP32PWM::setup(double freq, uint8_t resolution_bits) {
 
 	resolutionBits = resolution_bits;
 	if (attached()) {
-		ledcDetach(pin);
-		double val = ledcAttach(getPin(), freq, resolution_bits);
+		ledcDetachPin(pin);
+		double val = ledcAttachPin(getPin(), freq, resolution_bits);
 		attachPin(pin);
 		return val;
 	}
-	return ledcAttach(getPin(), freq, resolution_bits);
+	return ledcAttachPin(getPin(), freq, resolution_bits);
 }
 double ESP32PWM::getDutyScaled() {
 	return mapf((double) myDuty, 0, (double) ((1 << resolutionBits) - 1), 0.0,
@@ -169,11 +169,11 @@ void ESP32PWM::adjustFrequencyLocal(double freq, double dutyScaled) {
 	timerFreqSet[getTimer()] = (long) freq;
 	myFreq = freq;
 	if (attached()) {
-		ledcDetach(pin);
+		ledcDetachPin(pin);
 		// Remove the PWM during frequency adjust
 		_ledcSetupTimerFreq(getPin(), freq, resolutionBits);
 		writeScaled(dutyScaled);
-		ledcAttach(getPin(), freq, resolutionBits); // re-attach the pin after frequency adjust
+		ledcAttachPin(getPin(), freq, resolutionBits); // re-attach the pin after frequency adjust
 	} else {
 		_ledcSetupTimerFreq(getPin(), freq, resolutionBits);
 		writeScaled(dutyScaled);
@@ -234,7 +234,7 @@ void ESP32PWM::attachPin(uint8_t pin) {
 
 	if (hasPwm(pin)) {
 		attach(pin);
-		ledcAttach(pin, readFreq(), resolutionBits);
+		ledcAttachPin(pin, readFreq(), resolutionBits);
 	} else {
 		
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
@@ -261,7 +261,7 @@ void ESP32PWM::attachPin(uint8_t pin, double freq, uint8_t resolution_bits) {
 	attachPin(pin);
 }
 void ESP32PWM::detachPin(int pin) {
-	ledcDetach(pin);
+	ledcDetachPin(pin);
 	deallocate();
 }
 /* Side effects of frequency changes happen because of shared timers


### PR DESCRIPTION
I use wokwi website and i run my coding, but the error was appear as :
/libraries/ESP32Servo/src/ESP32PWM.cpp: In destructor 'virtual ESP32PWM::~ESP32PWM()':
/libraries/ESP32Servo/src/ESP32PWM.cpp:53:3: error: 'ledcDetach' was not declared in this scope
   ledcDetach(pin);
   ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:53:3: note: suggested alternative: 'ledcDetachPin'
   ledcDetach(pin);
   ^~~~~~~~~~
   ledcDetachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp: In static member function 'static double ESP32PWM::_ledcSetupTimerFreq(uint8_t, double, uint8_t)':
/libraries/ESP32Servo/src/ESP32PWM.cpp:60:9: error: 'ledcAttach' was not declared in this scope
  return ledcAttach(pin, freq, bit_num);
         ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:60:9: note: suggested alternative: 'ledcAttachPin'
  return ledcAttach(pin, freq, bit_num);
         ^~~~~~~~~~
         ledcAttachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp: In member function 'double ESP32PWM::setup(double, uint8_t)':
/libraries/ESP32Servo/src/ESP32PWM.cpp:150:3: error: 'ledcDetach' was not declared in this scope
   ledcDetach(pin);
   ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:150:3: note: suggested alternative: 'ledcDetachPin'
   ledcDetach(pin);
   ^~~~~~~~~~
   ledcDetachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp:151:16: error: 'ledcAttach' was not declared in this scope
   double val = ledcAttach(getPin(), freq, resolution_bits);
                ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:151:16: note: suggested alternative: 'ledcAttachPin'
   double val = ledcAttach(getPin(), freq, resolution_bits);
                ^~~~~~~~~~
                ledcAttachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp:155:9: error: 'ledcAttach' was not declared in this scope
  return ledcAttach(getPin(), freq, resolution_bits);
         ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:155:9: note: suggested alternative: 'ledcAttachPin'
  return ledcAttach(getPin(), freq, resolution_bits);
         ^~~~~~~~~~
         ledcAttachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp: In member function 'void ESP32PWM::adjustFrequencyLocal(double, double)':
/libraries/ESP32Servo/src/ESP32PWM.cpp:172:3: error: 'ledcDetach' was not declared in this scope
   ledcDetach(pin);
   ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:172:3: note: suggested alternative: 'ledcDetachPin'
   ledcDetach(pin);
   ^~~~~~~~~~
   ledcDetachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp:176:3: error: 'ledcAttach' was not declared in this scope
   ledcAttach(getPin(), freq, resolutionBits); // re-attach the pin after frequency adjust
   ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:176:3: note: suggested alternative: 'ledcAttachPin'
   ledcAttach(getPin(), freq, resolutionBits); // re-attach the pin after frequency adjust
   ^~~~~~~~~~
   ledcAttachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp: In member function 'void ESP32PWM::attachPin(uint8_t)':
/libraries/ESP32Servo/src/ESP32PWM.cpp:237:3: error: 'ledcAttach' was not declared in this scope
   ledcAttach(pin, readFreq(), resolutionBits);
   ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:237:3: note: suggested alternative: 'ledcAttachPin'
   ledcAttach(pin, readFreq(), resolutionBits);
   ^~~~~~~~~~
   ledcAttachPin
/libraries/ESP32Servo/src/ESP32PWM.cpp: In member function 'void ESP32PWM::detachPin(int)':
/libraries/ESP32Servo/src/ESP32PWM.cpp:264:2: error: 'ledcDetach' was not declared in this scope
  ledcDetach(pin);
  ^~~~~~~~~~
/libraries/ESP32Servo/src/ESP32PWM.cpp:264:2: note: suggested alternative: 'ledcDetachPin'
  ledcDetach(pin);
  ^~~~~~~~~~
  ledcDetachPin

Error during build: exit status 1
