### PR TITLE
Updated ESP32PWM.cpp to avoid checks on old ledAttachPin function

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -304,15 +304,15 @@ void ESP32PWM::attachPin(uint8_t pin) {
 
 	if (hasPwm(pin)) {
 		attach(pin);
-		bool success;
+		bool success=true;
 #ifdef ESP_ARDUINO_VERSION_MAJOR
 #if ESP_ARDUINO_VERSION >= ESP_ARDUINO_VERSION_VAL(3, 0, 0)
 		success=ledcAttach(pin, readFreq(), resolutionBits);
 #else
-		success=ledcAttachPin(pin, getChannel());
+		ledcAttachPin(pin, getChannel());
 #endif
 #else
-		success=ledcAttachPin(pin, getChannel());
+		ledcAttachPin(pin, getChannel());
 #endif
 		if(success)
 			return;


### PR DESCRIPTION
the old ledcAttachPin is a void function not able to return succes boolean, this makes the library crash when compiling with ESP_ARDUINO_VERSION < 3.0.0, this changes fixes issue #58, tested and compiled succesfully for my dev esp32c3 board with ESP_ARDUINO_VERSION = 2.0.9