### PR TITLE
Fixed bug of using wrong pin for detach in setup() + another bug + improvement

### DIFF
--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -24,6 +24,13 @@
 #define USABLE_ESP32_PWM (NUM_PWM-PWM_BASE_INDEX)
 #include <cstdint>
 
+#if !defined(ESP_ARDUINO_VERSION)
+#define ESP_ARDUINO_VERSION 0x010101 // Version 1.1.1
+#endif
+#if !defined(ESP_ARDUINO_VERSION_VAL)
+#define ESP_ARDUINO_VERSION_VAL(major, minor, patch) ((major << 16) | (minor << 8) | (patch))
+#endif
+
 class ESP32PWM {
 private:
 
@@ -50,9 +57,9 @@ private:
 		return (x - in_min) * (out_max - out_min) / (in_max - in_min) + out_min;
 	}
 
-	double setup(double freq, uint8_t resolution_bits=10);
+	bool setup(uint8_t pin, double freq, uint8_t resolution_bits=10);
 	//channel 0-15 resolution 1-16bits freq limits depend on resolution9
-	void attachPin(uint8_t pin);
+	bool attachPin(uint8_t pin);
 	// pin allocation
 	void deallocate();
 public:


### PR DESCRIPTION
- Improved ESP_ARDUINO_VERSION handling.
- Fixed bug of using wrong pin for detach in setup(). 
- Fixed bug of calling ledcAttach() twice for same pin.

Without this fixed I got:
[ 7634][E][esp32-hal-periman.c:180] perimanGetPinBus(): Invalid pin: 255
[ 7641][E][esp32-hal-periman.c:122] perimanSetPinBus(): Invalid pin: 255
[ 7647][E][esp32-hal-ledc.c:116] ledcAttachChannel(): Pin 255 is already attached to another bus and failed to detach