### PR TITLE
Fix for ESP32C6, ESP32C3 & ESP32H2

### DIFF
--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -116,8 +116,15 @@ public:
 				(pin >= 35 && pin <= 45) || //11
 				(pin == 47) || (pin == 48)) //2
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
-		if ((pin >=1 && pin <= 10) || //11
+		if ((pin >=0 && pin <= 10) || //11
 				(pin >= 18 && pin <= 21)) //4
+#elif defined(CONFIG_IDF_TARGET_ESP32C6)
+		if ((pin >=0 && pin <= 9) || //10
+				(pin >= 12 && pin <= 23)) //12
+#elif defined(CONFIG_IDF_TARGET_ESP32H2)
+		if ((pin >=0 && pin <= 5) || //6
+				(pin >= 8 && pin <= 14) || //7
+				(pin >= 22 && pin <= 27)) //6
 #else
 		if ((pin == 2) || //1
 				(pin == 4) || //1


### PR DESCRIPTION
This PR fixes PWM not working on some pins on ESP32C6, ESP32C3 & ESP32H2. 
The code was tested using our GLYPHC6, GLYPHC3 & GLYPHH2 ( Servo / PWM works on all the pins ). 

GLYPHC3 : https://shop.pcbcupid.com/product/gd001/
GLYPHC6 : https://shop.pcbcupid.com/product/gd002/
GLYPHH2 : https://shop.pcbcupid.com/product/gd003/