### PR TITLE
Fix format specifiers in ESP_LOG calls

### DIFF
--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -132,7 +132,7 @@ int ESP32PWM::allocatenext(double freq) {
 		return pwmChannel;
 	}
 	ESP_LOGE(TAG, 
-			"ERROR All PWM timers allocated! Can't accomodate %d Hz\r\nHalting...", freq);
+			"ERROR All PWM timers allocated! Can't accomodate %.3f Hz\r\nHalting...", freq);
 	while (1)
 		;
 }
@@ -316,7 +316,7 @@ void ESP32PWM::attachPin(uint8_t pin) {
 #endif
 		if(success)
 			return;
-		ESP_LOGE(TAG, "ERROR PWM channel failed to configure on!",pin);
+		ESP_LOGE(TAG, "ERROR PWM channel failed to configure on pin %d!", pin);
 		return;
 	}
 		
@@ -390,10 +390,10 @@ bool ESP32PWM::checkFrequencyForSideEffects(double freq) {
 					ESP_LOGW(TAG, 
 							"\tWARNING PWM channel %d	\
 							 shares a timer with channel %d\n	\
-							\tchanging the frequency to %d		\
+							\tchanging the frequency to %.3f		\
 							Hz will ALSO change channel %d	\
-							\n\tfrom its previous frequency of %d Hz\n "
-								,pwmChannel, pwm, freq,pwm, ChannelUsed[pwm]->myFreq);
+							\n\tfrom its previous frequency of %.3f Hz\n "
+								,pwmChannel, pwm, freq, pwm, ChannelUsed[pwm]->myFreq);
 					ChannelUsed[pwm]->myFreq = freq;
 				}
 			}


### PR DESCRIPTION
Attempting to build with ESP-IDF (v5.4.1) with arduino-esp32 as a component, I received the following error messages related to format specifiers:
```
In file included from /opt/esp/idf/components/log/include/esp_log.h:15,
                 from /workspaces/test-project/components/arduino/cores/esp32/esp32-hal-log.h:317,
                 from /workspaces/test-project/components/arduino/cores/esp32/esp32-hal.h:85,
                 from /workspaces/test-project/components/arduino/cores/esp32/Arduino.h:45,
                 from /workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.h:12,
                 from /workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:8:
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp: In member function 'int ESP32PWM::allocatenext(double)':
/opt/esp/idf/components/log/include/esp_log_color.h:98:31: error: format '%d' expects argument of type 'int', but argument 6 has type 'double' [-Werror=format=]
   98 | #define LOG_COLOR_E           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_E'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:164:86: note: in expansion of macro 'LOG_FORMAT'
  164 |         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:134:9: note: in expansion of macro 'ESP_LOGE'
  134 |         ESP_LOGE(TAG,
      |         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:99:31: error: format '%d' expects argument of type 'int', but argument 6 has type 'double' [-Werror=format=]
   99 | #define LOG_COLOR_W           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_W'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:165:86: note: in expansion of macro 'LOG_FORMAT'
  165 |         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:134:9: note: in expansion of macro 'ESP_LOGE'
  134 |         ESP_LOGE(TAG,
      |         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:101:31: error: format '%d' expects argument of type 'int', but argument 6 has type 'double' [-Werror=format=]
  101 | #define LOG_COLOR_D           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_D'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:166:86: note: in expansion of macro 'LOG_FORMAT'
  166 |         else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:134:9: note: in expansion of macro 'ESP_LOGE'
  134 |         ESP_LOGE(TAG,
      |         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:102:31: error: format '%d' expects argument of type 'int', but argument 6 has type 'double' [-Werror=format=]
  102 | #define LOG_COLOR_V           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_V'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:167:86: note: in expansion of macro 'LOG_FORMAT'
  167 |         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:134:9: note: in expansion of macro 'ESP_LOGE'
  134 |         ESP_LOGE(TAG,
      |         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:100:31: error: format '%d' expects argument of type 'int', but argument 6 has type 'double' [-Werror=format=]
  100 | #define LOG_COLOR_I           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_I'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:168:86: note: in expansion of macro 'LOG_FORMAT'
  168 |         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:134:9: note: in expansion of macro 'ESP_LOGE'
  134 |         ESP_LOGE(TAG,
      |         ^~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp: In member function 'void ESP32PWM::attachPin(uint8_t)':
/opt/esp/idf/components/log/include/esp_log_color.h:98:31: error: too many arguments for format [-Werror=format-extra-args]
   98 | #define LOG_COLOR_E           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_E'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:164:86: note: in expansion of macro 'LOG_FORMAT'
  164 |         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:319:17: note: in expansion of macro 'ESP_LOGE'
  319 |                 ESP_LOGE(TAG, "ERROR PWM channel failed to configure on!",pin);
      |                 ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:99:31: error: too many arguments for format [-Werror=format-extra-args]
   99 | #define LOG_COLOR_W           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_W'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:165:86: note: in expansion of macro 'LOG_FORMAT'
  165 |         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:319:17: note: in expansion of macro 'ESP_LOGE'
  319 |                 ESP_LOGE(TAG, "ERROR PWM channel failed to configure on!",pin);
      |                 ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:101:31: error: too many arguments for format [-Werror=format-extra-args]
  101 | #define LOG_COLOR_D           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_D'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:166:86: note: in expansion of macro 'LOG_FORMAT'
  166 |         else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:319:17: note: in expansion of macro 'ESP_LOGE'
  319 |                 ESP_LOGE(TAG, "ERROR PWM channel failed to configure on!",pin);
      |                 ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:102:31: error: too many arguments for format [-Werror=format-extra-args]
  102 | #define LOG_COLOR_V           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_V'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:167:86: note: in expansion of macro 'LOG_FORMAT'
  167 |         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:319:17: note: in expansion of macro 'ESP_LOGE'
  319 |                 ESP_LOGE(TAG, "ERROR PWM channel failed to configure on!",pin);
      |                 ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:100:31: error: too many arguments for format [-Werror=format-extra-args]
  100 | #define LOG_COLOR_I           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_I'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:168:86: note: in expansion of macro 'LOG_FORMAT'
  168 |         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:106:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  106 | #define ESP_LOGE( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_ERROR,   tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:319:17: note: in expansion of macro 'ESP_LOGE'
  319 |                 ESP_LOGE(TAG, "ERROR PWM channel failed to configure on!",pin);
      |                 ^~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp: In member function 'bool ESP32PWM::checkFrequencyForSideEffects(double)':
/opt/esp/idf/components/log/include/esp_log_color.h:98:31: error: format '%d' expects argument of type 'int', but argument 8 has type 'double' [-Werror=format=]
   98 | #define LOG_COLOR_E           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_E'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:164:86: note: in expansion of macro 'LOG_FORMAT'
  164 |         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:98:31: error: format '%d' expects argument of type 'int', but argument 10 has type 'double' [-Werror=format=]
   98 | #define LOG_COLOR_E           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_E'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:164:86: note: in expansion of macro 'LOG_FORMAT'
  164 |         if (level==ESP_LOG_ERROR )          { esp_log_write(ESP_LOG_ERROR,      tag, LOG_FORMAT(E, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:99:31: error: format '%d' expects argument of type 'int', but argument 8 has type 'double' [-Werror=format=]
   99 | #define LOG_COLOR_W           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_W'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:165:86: note: in expansion of macro 'LOG_FORMAT'
  165 |         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:99:31: error: format '%d' expects argument of type 'int', but argument 10 has type 'double' [-Werror=format=]
   99 | #define LOG_COLOR_W           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_W'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:165:86: note: in expansion of macro 'LOG_FORMAT'
  165 |         else if (level==ESP_LOG_WARN )      { esp_log_write(ESP_LOG_WARN,       tag, LOG_FORMAT(W, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:101:31: error: format '%d' expects argument of type 'int', but argument 8 has type 'double' [-Werror=format=]
  101 | #define LOG_COLOR_D           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_D'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:166:86: note: in expansion of macro 'LOG_FORMAT'
  166 |         else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:101:31: error: format '%d' expects argument of type 'int', but argument 10 has type 'double' [-Werror=format=]
  101 | #define LOG_COLOR_D           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_D'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:166:86: note: in expansion of macro 'LOG_FORMAT'
  166 |         else if (level==ESP_LOG_DEBUG )     { esp_log_write(ESP_LOG_DEBUG,      tag, LOG_FORMAT(D, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:102:31: error: format '%d' expects argument of type 'int', but argument 8 has type 'double' [-Werror=format=]
  102 | #define LOG_COLOR_V           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_V'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:167:86: note: in expansion of macro 'LOG_FORMAT'
  167 |         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:102:31: error: format '%d' expects argument of type 'int', but argument 10 has type 'double' [-Werror=format=]
  102 | #define LOG_COLOR_V           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_V'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:167:86: note: in expansion of macro 'LOG_FORMAT'
  167 |         else if (level==ESP_LOG_VERBOSE )   { esp_log_write(ESP_LOG_VERBOSE,    tag, LOG_FORMAT(V, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:100:31: error: format '%d' expects argument of type 'int', but argument 8 has type 'double' [-Werror=format=]
  100 | #define LOG_COLOR_I           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_I'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:168:86: note: in expansion of macro 'LOG_FORMAT'
  168 |         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
/opt/esp/idf/components/log/include/esp_log_color.h:100:31: error: format '%d' expects argument of type 'int', but argument 10 has type 'double' [-Werror=format=]
  100 | #define LOG_COLOR_I           ""
/opt/esp/idf/components/log/include/esp_log.h:62:37: note: in expansion of macro 'LOG_COLOR_I'
   62 | #define LOG_FORMAT(letter, format)  LOG_COLOR_ ## letter #letter " (%" PRIu32 ") %s: " format LOG_RESET_COLOR "\n"
      |                                     ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:168:86: note: in expansion of macro 'LOG_FORMAT'
  168 |         else                                { esp_log_write(ESP_LOG_INFO,       tag, LOG_FORMAT(I, format), esp_log_timestamp(), tag __VA_OPT__(,) __VA_ARGS__); } \
      |                                                                                      ^~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:205:38: note: in expansion of macro 'ESP_LOG_LEVEL'
  205 |         if (_ESP_LOG_ENABLED(level)) ESP_LOG_LEVEL(level, tag, format, ##__VA_ARGS__); \
      |                                      ^~~~~~~~~~~~~
/opt/esp/idf/components/log/include/esp_log.h:107:38: note: in expansion of macro 'ESP_LOG_LEVEL_LOCAL'
  107 | #define ESP_LOGW( tag, format, ... ) ESP_LOG_LEVEL_LOCAL(ESP_LOG_WARN,    tag, format __VA_OPT__(,) __VA_ARGS__)
      |                                      ^~~~~~~~~~~~~~~~~~~
/workspaces/test-project/components/esp32servo/ESP32Servo/src/ESP32PWM.cpp:390:41: note: in expansion of macro 'ESP_LOGW'
  390 |                                         ESP_LOGW(TAG,
      |                                         ^~~~~~~~
cc1plus: some warnings being treated as errors
make[2]: *** [esp-idf/esp32servo/CMakeFiles/__idf_esp32servo.dir/build.make:76: esp-idf/esp32servo/CMakeFiles/__idf_esp32servo.dir/ESP32Servo/src/ESP32PWM.cpp.obj] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:7128: esp-idf/esp32servo/CMakeFiles/__idf_esp32servo.dir/all] Error 2
```

This PR fixes the warnings/errors above.