### PR TITLE
Adding MCPWM support for the ESP32S3 to enable using 20 PWM channels when sharing MCPWM channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,52 @@
-# Servo Library for ESP32
+# Enhanced Servo Library for ESP32
 
-Specifically for the V3.0.0 of Arduino ESP32. All ADC's have been updated to work correctly with the new release
+Compatible with Arduino ESP32 v3.0.0+ with advanced PWM hardware support.
 
 https://github.com/espressif/arduino-esp32/releases
 
-This library attempts to faithfully replicate the semantics of the
-Arduino Servo library (see http://www.arduino.cc/en/Reference/Servo)
-for the ESP32, with two (optional) additions. The two new functions
-expose the ability of the ESP32 PWM timers to vary timer width.
+This library provides enhanced PWM control for ESP32 boards, faithfully replicating Arduino Servo semantics while adding advanced hardware support:
+
+## Key Features
+
+- **ESP32S3 MCPWM Support**: Hardware-accelerated servo control for optimal timing precision
+- **Dual Hardware Architecture**: 20 PWM channels (8 LEDC + 12 MCPWM) with intelligent allocation
+- **Flexible Frequency Modes**: Variable-frequency PWM and fixed-frequency servo control
+- **Automatic Fallback**: Seamless hardware allocation when preferred resources are unavailable
+- **Backward Compatible**: Drop-in replacement for existing Arduino Servo code
+
+## Hardware Support
+
+| ESP32 Variant | LEDC Channels | MCPWM Channels | Total Channels |
+|---------------|---------------|----------------|----------------|
+| ESP32S3       | 8             | 12             | 20             |
+| ESP32S2       | 8             | -              | 8              |
+| ESP32         | 16            | -              | 16             |
+| ESP32C3       | 6             | -              | 6              |
+
+## Usage Examples
+
+### Basic Servo Control
+```cpp
+#include <ESP32Servo.h>
+
+Servo myservo;
+myservo.attach(18);        // Attach to pin 18
+myservo.write(90);         // Set to 90 degrees
+```
+
+### Advanced PWM Control
+```cpp
+#include <ESP32PWM.h>
+
+// Variable frequency (default) - LEDC preferred
+ESP32PWM pwm1;             // or ESP32PWM pwm1(true);
+
+// Fixed frequency - MCPWM preferred
+ESP32PWM pwm2(false);      // Optimal for servos
+
+pwm1.attachPin(19, 1000, 10);  // 1kHz, 10-bit resolution
+pwm2.attachPin(21, 50, 10);    // 50Hz, 10-bit resolution
+```
 # Documentation by Doxygen
 
 [ESP32Servo Doxygen](https://madhephaestus.github.io/ESP32Servo/annotated.html)
@@ -91,4 +130,8 @@ MINIMUM pulse with: 500us
 
 MAXIMUM pulse with: 2500us
 
-MAXIMUM number of servos: 16 (this is the number of PWM channels in the ESP32)  
+MAXIMUM number of servos: Varies by ESP32 variant
+- ESP32S3: 20 channels (8 LEDC + 12 MCPWM)
+- ESP32: 16 channels (16 LEDC)
+- ESP32S2: 8 channels (8 LEDC)
+- ESP32C3: 6 channels (6 LEDC)

--- a/examples/AllOutputsSimultaneous/AllOutputsSimultaneous.ino
+++ b/examples/AllOutputsSimultaneous/AllOutputsSimultaneous.ino
@@ -1,0 +1,75 @@
+/*
+ * AllOutputsSimultaneous
+ *
+ * This example demonstrates driving all 20 available PWM outputs simultaneously
+ * on the ESP32 S3 using a mix of MCPWM and LEDC hardware.
+ *
+ * The ESP32 S3 supports 20 PWM channels:
+ * - 8 LEDC channels (shared timers)
+ * - 12 MCPWM channels (6 timers × 2 operators each for shared frequency)
+ *
+ * This example uses:
+ * - 12 ESP32PWM objects with default settings (MCPWM, shared frequency)
+ * - 8 ESP32PWM objects with variable frequency (LEDC channels)
+ *
+ * Circuit:
+ * Connect servo motors or LEDs to the PWM pins listed below.
+ * Ensure adequate power supply for servos (ESP32 3.3V may not be sufficient).
+ */
+
+#include <ESP32PWM.h>
+
+// ESP32 S3 PWM pins: 1-21, 35-45, 47-48
+// We'll use 20 pins from the available ones
+int pwmPins20[20] = {
+  1, 2, 3, 4, 5, 6, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,  // 15 pins
+ 37, 38, 39  // 5 more = 20 total
+};
+
+ESP32PWM* pwms[20];  // Array of 20 PWM objects
+
+int duty = 0;        // Current duty cycle (0-255 for 8-bit resolution)
+int increment = 1;   // Duty increment
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println("Setting up 20 simultaneous PWM outputs...");
+
+  // Allocate all LEDC timers for maximum LEDC channels
+  ESP32PWM::allocateTimer(0);
+  ESP32PWM::allocateTimer(1);
+  ESP32PWM::allocateTimer(2);
+  ESP32PWM::allocateTimer(3);
+
+  // Create first 12 PWM objects with default settings (MCPWM, shared frequency)
+  // These will share timers and thus frequencies
+  for (int i = 0; i < 20; i++) {
+    pwms[i] = new ESP32PWM(false);  // false = shared frequency
+    pwms[i]->attachPin(pwmPins20[i], 50, 10);  // 50Hz, 10-bit resolution
+    if (pwms[i]->attached()) {
+      Serial.printf("Attached PWM %d to pin %d (MCPWM shared)\n", i, pwmPins20[i]);
+    } else {
+      Serial.printf("Failed to attach PWM %d to pin %d\n", i, pwmPins20[i]);
+    }
+  }
+
+  Serial.printf("Total PWM channels remaining: %d\n", ESP32PWM::channelsRemaining());
+  Serial.println("Setup complete. Starting simultaneous PWM sweep...");
+}
+
+void loop() {
+  // Set all PWM outputs to the same duty cycle for simultaneous control
+  for (int i = 0; i < 20; i++) {
+    pwms[i]->writeScaled((float)duty / 255.0);  // Convert to 0.0-1.0 range
+  }
+
+  Serial.printf("All PWM outputs set to duty cycle: %d/255\n", duty);
+
+  // Update duty cycle
+  duty += increment;
+  if (duty >= 255 || duty <= 0) {
+    increment = -increment;  // Reverse direction at limits
+  }
+
+  delay(10);  // Small delay for visible changes
+}

--- a/library.properties
+++ b/library.properties
@@ -1,11 +1,10 @@
 name=ESP32Servo
-version=3.0.9
+version=3.1.0
 author=Kevin Harrington,John K. Bennett
 maintainer=Kevin Harrington <mad.hephaestus@gmail.com>
-sentence=Allows ESP32 boards to control servo, tone and analogWrite motors using Arduino semantics. 
-paragraph=This library can control a many types of servos.<br />It makes use of the ESP32 PWM timers: the library can control up to 16 servos on individual channels<br />No attempt has been made to support multiple servos per channel.<br />
+sentence=Allows ESP32 PWM library with MCPWM support for optimal servo performance.
+paragraph=This library provides advanced PWM control for ESP32 boards using LEDC hardware, with enhanced MCPWM support on ESP32S3.<br />ESP32S3: 20 PWM channels (8 LEDC + 12 MCPWM) with intelligent allocation<br />All ESP32 variants: LEDC-based PWM with variable-frequency support<br />Supports variable-frequency PWM and fixed-frequency servo control<br />Automatic hardware fallback ensures maximum channel availability<br />
 category=Device Control
 url=https://madhephaestus.github.io/ESP32Servo/annotated.html
 architectures=esp32
 includes=ESP32Servo.h,analogWrite.h,tone.h,ESP32Tone.h,ESP32PWM.h
-

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -1,8 +1,26 @@
 /*
- * ESP32PWM.h
+ * ESP32PWM.h - Enhanced PWM Library for ESP32
  *
- *  Created on: Sep 22, 2018
- *      Author: hephaestus
+ * This library provides PWM functionality for ESP32 chips with support for:
+ * - ESP32S3: MCPWM hardware acceleration for optimal servo performance
+ * - Variable frequency mode: LEDC preferred, MCPWM fallback for flexibility
+ * - Fixed frequency mode: MCPWM preferred, LEDC fallback for shared timers
+ * - Automatic hardware allocation with intelligent fallbacks
+ *
+ * Key Features:
+ * - Dual hardware support (LEDC + MCPWM on S3)
+ * - 20 total PWM channels on ESP32S3 (8 LEDC + 12 MCPWM)
+ * - Frequency locking for fixed-frequency applications (servos)
+ * - Seamless hardware fallback when preferred hardware unavailable
+ *
+ * Usage:
+ * - ESP32PWM pwm;                    // Variable frequency (default)
+ * - ESP32PWM pwm(true);              // Variable frequency (explicit)
+ * - ESP32PWM pwm(false);             // Fixed frequency
+ *
+ * Created on: Sep 22, 2018
+ * Author: hephaestus
+ * Enhanced for ESP32S3 MCPWM support
  */
 
 #ifndef LIBRARIES_ESP32SERVO_SRC_ESP32PWM_H_
@@ -16,8 +34,24 @@
 #define NUM_PWM 6
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)   ||  defined(CONFIG_IDF_TARGET_ESP32S3)
 #define NUM_PWM 8
-#else 
+#else
 #define NUM_PWM 16
+#endif
+
+// MCPWM support for ESP32S3
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+#include "driver/mcpwm.h"
+#define MCPWM_NUM_UNITS 2
+#define MCPWM_NUM_TIMERS_PER_UNIT 3
+#define MCPWM_NUM_OPERATORS_PER_TIMER 2
+
+struct MCPWMTimerInfo {
+    bool initialized = false;
+    long freq = -1;
+    int operatorCount = 0;
+    ESP32PWM* operators[MCPWM_NUM_OPERATORS_PER_TIMER] = {nullptr, nullptr};
+};
+
 #endif
 
 #define PWM_BASE_INDEX 0
@@ -33,7 +67,15 @@ private:
 	int pin;
 	uint8_t resolutionBits;
 	double myFreq;
+	bool useVariableFrequency = false;
+	bool isMCPWM = false;
 	int allocatenext(double freq);
+
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+	mcpwm_unit_t mcpwmUnit;
+	mcpwm_timer_t mcpwmTimer;
+	mcpwm_operator_t mcpwmOperator;
+#endif
 
 	static double _ledcSetupTimerFreq(uint8_t pin, double freq,
 		uint8_t bit_num, uint8_t channel);
@@ -57,7 +99,7 @@ private:
 	void deallocate();
 public:
 	// setup
-	ESP32PWM();
+	ESP32PWM(bool variableFrequency = true);  // true=variable freq (LEDC preferred), false=fixed freq (MCPWM preferred)
 	virtual ~ESP32PWM();
 
 
@@ -71,7 +113,7 @@ public:
 	void write(uint32_t duty);
 	// Write a duty cycle to the PWM using a unit vector from 0.0-1.0
 	void writeScaled(double duty);
-	//Adjust frequency
+	//Adjust frequency (only works on variable-frequency channels)
 	double writeTone(double freq);
 	double writeNote(note_t note, uint8_t octave);
 	void adjustFrequency(double freq, double dutyScaled=-1);
@@ -101,6 +143,10 @@ public:
 	static int timerCount[4];
 	static ESP32PWM * ChannelUsed[NUM_PWM]; // used to track whether a channel is in service
 	static long timerFreqSet[4];
+
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+	static MCPWMTimerInfo mcpwmTimers[MCPWM_NUM_UNITS][MCPWM_NUM_TIMERS_PER_UNIT];
+#endif
 
 	// Helper functions
 	int getPin() {
@@ -138,7 +184,11 @@ public:
 		return false;
 	}
 	static int channelsRemaining() {
+#if defined(CONFIG_IDF_TARGET_ESP32S3)
+		return NUM_PWM + (MCPWM_NUM_UNITS * MCPWM_NUM_TIMERS_PER_UNIT * MCPWM_NUM_OPERATORS_PER_TIMER) - PWMCount;
+#else
 		return NUM_PWM - PWMCount;
+#endif
 	}
 	static boolean DISABLE_DAC;
 

--- a/src/ESP32Servo.h
+++ b/src/ESP32Servo.h
@@ -1,9 +1,25 @@
 /*
  Copyright (c) 2017 John K. Bennett. All right reserved.
 
- ESP32_Servo.h - Servo library for ESP32 - Version 1
+ ESP32_Servo.h - Enhanced Servo library for ESP32 - Version 1
 
  Original Servo.h written by Michael Margolis in 2009
+
+ This library provides servo control with optimized hardware support:
+ - ESP32S3: MCPWM hardware acceleration for precise servo timing
+ - Fixed frequency mode for consistent servo operation
+ - Automatic hardware allocation with LEDC fallback
+
+ Key Features:
+ - Uses fixed-frequency PWM for servo compatibility
+ - MCPWM preferred on S3, LEDC fallback for maximum channels
+ - 50Hz default frequency with 1000-2000us pulse range
+ - Up to 16 servo channels (limited by available PWM hardware)
+
+ Usage:
+ - Servo myservo;              // Create servo instance
+ - myservo.attach(pin);        // Attach to pin with default range
+ - myservo.write(angle);       // Set servo angle (0-180 degrees)
 
  This library is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public
@@ -101,7 +117,7 @@
 //#define REFRESH_CPS            50
 #define REFRESH_USEC         20000
 
-#define MAX_SERVOS              16     // no. of PWM channels in ESP32
+#define MAX_SERVOS              20     // maximum PWM channels supported (varies by ESP32 variant)
 
 /*
  * This group/channel/timmer mapping is for information only;
@@ -164,7 +180,7 @@ private:
 	int ticks = DEFAULT_PULSE_WIDTH_TICKS; // current pulse width on this channel
 	int timer_width_ticks = DEFAULT_TIMER_WIDTH_TICKS; // no. of ticks at rollover; varies with width
 	ESP32PWM * getPwm(); // get the PWM object
-	ESP32PWM pwm;
+	ESP32PWM pwm{false}; // fixed frequency for servo use
 	int REFRESH_CPS = 50;
 
 };


### PR DESCRIPTION
The ESP32S3 only has 8 LED C Channels, thats not enough for anyone. This adds support for using its 2 mcpwm registers, each with 3 timers and each timer having 2 output channels. A timer can have any frequency set but bot channels must share the same frequency. Each channel can have its duty cycle varied independently. This change tries its best to catch all edge cases around that 