### PR TITLE
Fix: Resolve circular dependency in ESP32PWM.h

### DIFF
--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -45,6 +45,8 @@
 #define MCPWM_NUM_TIMERS_PER_UNIT 3
 #define MCPWM_NUM_OPERATORS_PER_TIMER 2
 
+class ESP32PWM; // Forward declaration
+
 struct MCPWMTimerInfo {
     bool initialized = false;
     long freq = -1;


### PR DESCRIPTION
Resolves issue where MCPWMTimerInfo uses ESP32PWM* before the class definition is parsed by the compiler.