### PR TITLE
Improved/ Added ESP32C5 LEDC Support & Error Messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This library provides enhanced PWM control for ESP32 boards, faithfully replicat
 | ESP32S2       | 8             | -              | 8              |
 | ESP32         | 16            | -              | 16             |
 | ESP32C3       | 6             | -              | 6              |
+| ESP32C5       | 6             | 6 (not implemented) | 12 (6 supported) |
 
 ## Usage Examples
 
@@ -135,3 +136,4 @@ MAXIMUM number of servos: Varies by ESP32 variant
 - ESP32: 16 channels (16 LEDC)
 - ESP32S2: 8 channels (8 LEDC)
 - ESP32C3: 6 channels (6 LEDC)
+- ESP32C5: 12 (6 implemented) channels (6 LEDC + 6 MCPWM (not supported))

--- a/src/ESP32PWM.cpp
+++ b/src/ESP32PWM.cpp
@@ -52,6 +52,8 @@ ESP32PWM::ESP32PWM(bool variableFrequency) : useVariableFrequency(variableFreque
 #if defined(CONFIG_IDF_TARGET_ESP32S3)
 		// MCPWMTimerInfo struct is initialized with default values in the struct definition
 		ESP_LOGI(TAG, "ESP32S3 detected - MCPWM support enabled");
+#elif defined(CONFIG_IDF_TARGET_ESP32C5)
+		ESP_LOGI(TAG, "ESP32C5 detected - MCPWM support not enabled");
 #else
 		ESP_LOGI(TAG, "Non-ESP32S3 target - using LEDC only");
 #endif
@@ -508,13 +510,15 @@ void ESP32PWM::attachPin(uint8_t pin) {
 	}
 
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
-	ESP_LOGE(TAG, "ERROR PWM channel unavailable on pin requested! %d PWM available on: 1-21,26,33-42", pin);
+	ESP_LOGE(TAG, "ERROR PWM channel unavailable on the ESP32S2 pin requested! %d PWM available on: 1-21,26,33-42", pin);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-	ESP_LOGE(TAG, "ERROR PWM channel unavailable on pin requested! %d PWM available on: 1-21,35-45,47-48", pin);
+	ESP_LOGE(TAG, "ERROR PWM channel unavailable on the ESP32S3 pin requested! %d PWM available on: 1-21,35-45,47-48", pin);
+#elif defined(CONFIG_IDF_TARGET_ESP32C5)
+	ESP_LOGE(TAG, "ERROR PWM channel unavailable on the ESP32C5 pin requested! %d PWM available on: 1-21,35-45,47-48", pin);
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
-	ESP_LOGE(TAG, "ERROR PWM channel unavailable on pin requested! %d PWM available on: 1-10,18-21", pin);
+	ESP_LOGE(TAG, "ERROR PWM channel unavailable on the ESP32C3 pin requested! %d PWM available on: 1-10,18-21", pin);
 #else
-	ESP_LOGE(TAG, "ERROR PWM channel unavailable on pin requested! %d PWM available on: 2,4,5,12-19,21-23,25-27,32-33", pin);
+	ESP_LOGE(TAG, "ERROR PWM channel unavailable on the ESP32 pin requested! %d PWM available on: 2,4,5,12-19,21-23,25-27,32-33", pin);
 #endif
 
 }

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -10,6 +10,7 @@
  * Key Features:
  * - Dual hardware support (LEDC + MCPWM on S3)
  * - 20 total PWM channels on ESP32S3 (8 LEDC + 12 MCPWM)
+ * - 12 (6 supported) total PWM channels on ESP32C5 (6 LEDC + 6 MCPWM (not supported by library yet))
  * - Frequency locking for fixed-frequency applications (servos)
  * - Seamless hardware fallback when preferred hardware unavailable
  *
@@ -34,6 +35,14 @@
 #define NUM_PWM 6
 #elif defined(CONFIG_IDF_TARGET_ESP32S2)   ||  defined(CONFIG_IDF_TARGET_ESP32S3)
 #define NUM_PWM 8
+#elif defined(CONFIG_IDF_TARGET_ESP32C5)
+/**
+ * @brief Number of PWM channels
+ * @details The ESP32C5 has 6 LEDC channels and 6 MCPWM channels, but the MCPWM channels require further changes
+ * @see Page 5 of https://documentation.espressif.com/esp32-c5_datasheet_en.pdf
+ */
+// #define NUM_PWM 12 // TODO: Add MCPWM support for the ESP32-C5
+#define NUM_PWM 6 // LEDC channels only
 #else
 #define NUM_PWM 16
 #endif

--- a/src/ESP32PWM.h
+++ b/src/ESP32PWM.h
@@ -175,6 +175,10 @@ public:
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
 		if ((pin >=0 && pin <= 10) || //11
 				(pin >= 18 && pin <= 21)) //4
+#elif defined(CONFIG_IDF_TARGET_ESP32C5)
+		if ((pin >=0 && pin <= 14) ||
+				(pin >= 12 && pin <= 14) ||
+				(pin >= 23 && pin <= 28))
 #elif defined(CONFIG_IDF_TARGET_ESP32C6)
 		if ((pin >=0 && pin <= 9) || //10
 				(pin >= 12 && pin <= 23)) //12

--- a/src/ESP32Servo.cpp
+++ b/src/ESP32Servo.cpp
@@ -107,13 +107,15 @@ if(
 #endif
 
 #if defined(CONFIG_IDF_TARGET_ESP32S2)
-				ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 1-21,26,33-42", pin);
+				ESP_LOGE(TAG, "This ESP32S2 pin can not be a servo: %d Servo available on: 1-21,26,33-42", pin);
 #elif defined(CONFIG_IDF_TARGET_ESP32S3)
-			    ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 1-21,35-45,47-48", pin);
+			    ESP_LOGE(TAG, "This ESP32S3 pin can not be a servo: %d Servo available on: 1-21,35-45,47-48", pin);
 #elif defined(CONFIG_IDF_TARGET_ESP32C3)
-				ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 1-10,18-21", pin);
+				ESP_LOGE(TAG, "This ESP32C3 pin can not be a servo: %d Servo available on: 1-10,18-21", pin);
+#elif defined(CONFIG_IDF_TARGET_ESP32C5)
+				ESP_LOGE(TAG, "This ESP32C5 pin can not be a servo: %d Servo available on: 0-14,12-14,23-28", pin);
 #else
-				ESP_LOGE(TAG, "This pin can not be a servo: %d Servo available on: 2,4,5,12-19,21-23,25-27,32-33",pin);
+				ESP_LOGE(TAG, "This ESP32 pin can not be a servo: %d Servo available on: 2,4,5,12-19,21-23,25-27,32-33",pin);
 #endif
             return 0;
         }


### PR DESCRIPTION
- Added LEDC support for the ESP32C5, including:
- Improved pin configuration check & error messages
- Updated documentation
- Squashed two of the three commits from my [previous pull request](https://github.com/madhephaestus/ESP32Servo/pull/104), although they probably could all be squashed.

See: #98 .